### PR TITLE
Add a workflow to publish documentation to Github Wiki

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -1,17 +1,13 @@
-Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
-or
-Link to the project management tool for the release
+https://github.com/nimblehq/github-actions-workflows/milestone/
 
 ## Features
 
-Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+Provide the Pull Request IDs in the section for each type (feature, chore, and bug), e.g.
 
-- [ch1234] As a user, I can log in
-or
-- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+- #1234
 
 ## Chores
-- Same structure as in  ## Feature
+- Same structure as in ## Feature
 
 ## Bugs
-- Same structure as in  ## Feature
+- Same structure as in ## Feature

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -6,7 +6,7 @@
 # https://docs.github.com/en/communities/documenting-your-project-with-wikis/adding-or-editing-wiki-pages#adding-wiki-pages
 # - Create Personal Access Token with `repo` scope enabled - a bot account is recommended to generate that token
 # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-# - Create a Repository Secret for the above token, e.g. name it as GH_WIKI_ACTION_TOKEN
+# - Create a Repository Secret for the above token, e.g. name it as GH_ACTION_TOKEN
 # - Define your own workflow and provide the required inputs & secret, here is an example workflow:
 # 
 # name: Publish Wiki
@@ -21,12 +21,12 @@
 # jobs:
 #   publish:
 #     name: Publish Wiki
-#     uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@feature/publish-wiki-workflow
+#     uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
 #     with:
 #       USER_NAME: github-wiki-action
 #       USER_EMAIL: github-wiki-action@example.com
 #     secrets:
-#       USER_TOKEN: ${{ secrets.GH_WIKI_ACTION_TOKEN }}
+#       USER_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
 
 name: Publish Wiki
 

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -1,0 +1,96 @@
+# This workflow will publish all of the documents stored under ./github/wiki directory 
+# to Github Wiki of the given repository.
+#
+# To use this workflow, please follow these steps
+# - Setup the Github Wiki by following this official guide
+# https://docs.github.com/en/communities/documenting-your-project-with-wikis/adding-or-editing-wiki-pages#adding-wiki-pages
+# - Create Personal Access Token with `repo` scope enabled - a bot account is recommended to generate that token
+# https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+# - Create a Repository Secret for the above token, e.g. name it as GH_WIKI_ACTION_TOKEN
+# - Define your own workflow and provide the required inputs & secret, here is an example workflow:
+# 
+# name: Publish Wiki
+#
+# on: 
+#   push:
+#     branches:
+#       - develop
+#     paths:
+#       - .github/wiki/**
+#
+# jobs:
+#   publish:
+#     name: Publish Wiki
+#     uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@feature/publish-wiki-workflow
+#     with:
+#       USER_NAME: github-wiki-action
+#       USER_EMAIL: github-wiki-action@example.com
+#     secrets:
+#       USER_TOKEN: ${{ secrets.GH_WIKI_ACTION_TOKEN }}
+
+name: Publish Wiki
+
+on:
+  workflow_call:
+    inputs:
+      # The username of a Github (bot) account
+      USER_NAME:
+        required: true
+        type: string
+      # The e-mail of a Github (bot) account
+      USER_EMAIL:
+        required: true
+        type: string
+    secrets:
+      # The Personal Access Token of a Github (bot) account
+      USER_TOKEN:
+        required: true
+
+env:
+  USER_NAME: ${{ inputs.USER_NAME }}
+  USER_EMAIL: ${{ inputs.USER_EMAIL }}
+  USER_TOKEN: ${{ secrets.USER_TOKEN }}
+  REPOSITORY: ${{ github.repository }}
+  WIKI_FOLDER: .github/wiki
+  TEMP_CLONE_WIKI_FOLDER: tmp_wiki
+
+jobs:
+  publish:
+    name: Publish Github Wiki
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      # This step will
+      # - Create folder named `tmp_wiki`
+      # - Initialize Git
+      # - Pull old Wiki content
+      - name: Pull current wiki content
+        run: |
+          mkdir $TEMP_CLONE_WIKI_FOLDER
+          cd $TEMP_CLONE_WIKI_FOLDER
+          git init
+          git config user.name $USER_NAME
+          git config user.email $USER_EMAIL
+          git pull https://$USER_TOKEN@github.com/$REPOSITORY.wiki.git
+
+      # This step will
+      # - Synchronize differences between `.github/wiki/` & `tmp_wiki`
+      # - Push new Wiki content
+      - name: Push new wiki content
+        run: |
+          rsync -av --delete $WIKI_FOLDER/ $TEMP_CLONE_WIKI_FOLDER/ --exclude .git
+          cd $TEMP_CLONE_WIKI_FOLDER
+          git add .
+          git commit -m "Update Wiki content"
+          git push -f --set-upstream https://$USER_TOKEN@github.com/$REPOSITORY.wiki.git master

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
-# Git Repository Template
+<p align="center">
+  <img alt="Nimble logo" src="https://assets.nimblehq.co/logo/light/logo-light-text-320.png" />
+</p>
 
-Project repository template to set up all public projects at [Nimble](https://nimblehq.co/)
+<p align="center">
+  <strong>A collection of reusable Github Actions Workflows at Nimble</strong>
+</p>
 
+---
 ## Usage
+Follow the [instruction](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow) from Github to use any workflows in this repository.
 
-Clone the repository
-
-`git clone git@github.com:nimblehq/git-template.git`
+## How to contribute
+- Refer to the [official guide](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#creating-a-reusable-workflow) to learn how to define a resuable workflow
+- Put the new workflow under `./github/workflows` directory
+- Follow our [convention](https://nimblehq.co/compass/development/code-conventions/github-actions/) when defining the workflow
+- Submit a [Pull rquest](https://github.com/nimblehq/github-actions-workflows/compare) to this repository
 
 ## License
 


### PR DESCRIPTION
## What happened 👀

This PR adds a reusable workflow to publish the documents stored under `.github/wiki` directory to Github Wiki of a given repository
 
## Insight 📝

- The workflow is mainly based on the work of Nimble's [Android Template](https://github.com/nimblehq/android-templates/pull/120)
- Utilize the support of [Reusable Workflow](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) for Github Actions
- To use this workflow, one can create a new workflow in any repository & provide the required inputs & secret, example:
```yml
name: Publish Wiki

on: 
  push:
    branches:
      - develop
    paths:
      - .github/wiki/**

jobs:
  publish:
    name: Publish Wiki
    uses: nimblehq/github-actions-workflows/.github/workflows/publish_wiki.yml@0.1.0
    with:
      USER_NAME: github-wiki-action
      USER_EMAIL: github-action@example.com
    secrets:
      USER_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
```
 
## Proof Of Work 📹

I create a dummy repo to use that repo for demo purposes and it works
- The PR to integrate the workflow: https://github.com/longnd/demo-reusable-workflows/pull/2/files
- The action run as expected: https://github.com/longnd/demo-reusable-workflows/actions/runs/1610532819
<img width="851" alt="Screen Shot 2021-12-22 at 16 19 19" src="https://user-images.githubusercontent.com/1896814/147068599-f130890c-2be9-4a53-88ad-bccbc12c862a.png">

