### PR TITLE
[Chore] Upgrade & pin GitHub actions to specific commit hashes for security and stability

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -62,12 +62,12 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # actions/checkout@v6.0.3
         with:
           ref: ${{ github.head_ref }}
 

--- a/create_release_pull_request/action.yml
+++ b/create_release_pull_request/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Generate changelog
       id: generate_changelog
-      uses: mikepenz/release-changelog-builder-action@v4
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # mikepenz/release-changelog-builder-action@v6.2.2
       with:
         token: ${{ inputs.github_token }}
         configuration: ${{ inputs.changelog_configuration }}

--- a/create_release_pull_request/sample/workflows/create_release_pull_request.yml
+++ b/create_release_pull_request/sample/workflows/create_release_pull_request.yml
@@ -12,11 +12,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # actions/checkout@v6.0.3
 
       - name: Read the current version
         id: version
-        uses: christian-draeger/read-properties@1.1.1
+        uses: christian-draeger/read-properties@908f99d3334be3802ec7cb528395a69d19914e7b # christian-draeger/read-properties@1.1.1
         with:
           path: "version.properties"
           properties: "version"


### PR DESCRIPTION


## What happened 👀

Upgrade & pin GitHub actions to specific commit hashes for security and stability


Action | SHA # tag
-- | --
styfle/cancel-workflow-action | d07a454… # 0.13.1
actions/checkout | df4cb1c… # v6.0.3
mikepenz/release-changelog-builder-action | 348e88f… # v6.2.2
christian-draeger/read-properties | 908f99d… # 1.1.1



## Insight 📝


## Proof Of Work 📹

